### PR TITLE
Redesign: static HTML/CSS/JS portfolio with SEO

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,16 +1,10 @@
 name: Deploy website to GitHub Pages
 
-env:
-  WC_HUGO_VERSION: '0.119.0'
-
 on:
-  # Trigger the workflow every time you push to the `main` branch
   push:
     branches: ["main"]
-  # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
-# Provide permission to clone the repo and deploy it to GitHub Pages
 permissions:
   contents: read
   pages: write
@@ -21,50 +15,20 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build website
-  build:
-    if: github.repository_owner != 'HugoBlox'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          # Fetch history for Hugo's .GitInfo and .Lastmod
-          fetch-depth: 0
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: ${{ env.WC_HUGO_VERSION }}
-          extended: true
-      - uses: actions/cache@v4
-        with:
-          path: /tmp/hugo_cache_runner/
-          key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-hugomod-
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
-      - name: Build with Hugo
-        env:
-          HUGO_ENVIRONMENT: production
-        run: |
-          echo "Hugo Cache Dir: $(hugo config | grep cachedir)"
-          hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./public
-
-  # Deploy website to GitHub Pages hosting
   deploy:
-    if: github.repository_owner != 'HugoBlox'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,1231 @@
+/* ============================================
+   Blaine Heffron — Portfolio
+   Aesthetic: Laboratory Elegance
+   A physicist's precision meets editorial design
+   ============================================ */
+
+/* Fonts loaded via <link> in HTML head for better LCP */
+
+/* --- Design Tokens --- */
+:root {
+  /* Dark palette (default) */
+  --bg-deep: #04050e;
+  --bg-primary: #080a18;
+  --bg-elevated: #0e1024;
+  --bg-card: #12142c;
+  --bg-card-hover: #1a1c3a;
+  --border: #1c1e3d;
+  --border-subtle: #141630;
+
+  --text-primary: #e6e6f0;
+  --text-secondary: #9294ae;
+  --text-muted: #5a5c74;
+
+  --accent: #00b4ec;
+  --accent-dim: rgba(0, 180, 236, 0.10);
+  --accent-glow: rgba(0, 180, 236, 0.22);
+  --accent-bright: #40d0ff;
+  --accent-text: #00b4ec;
+
+  --gold: #d4a030;
+  --gold-dim: rgba(212, 160, 48, 0.10);
+  --gold-glow: rgba(212, 160, 48, 0.18);
+  --gold-text: #e0b040;
+
+  --success: #34d399;
+  --tag-bg: rgba(0, 180, 236, 0.08);
+  --tag-text: #60c8e8;
+  --tag-border: rgba(0, 180, 236, 0.15);
+
+  /* Typography */
+  --font-display: 'Instrument Serif', Georgia, 'Times New Roman', serif;
+  --font-body: 'Outfit', system-ui, -apple-system, sans-serif;
+  --font-mono: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+
+  /* Spacing */
+  --section-pad: clamp(72px, 10vh, 128px);
+  --container-max: 1140px;
+  --container-pad: clamp(20px, 5vw, 48px);
+
+  /* Easing */
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* Radius */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+
+  --nav-height: 64px;
+  --theme: dark;
+}
+
+/* Light theme */
+[data-theme="light"] {
+  --bg-deep: #f8f8fc;
+  --bg-primary: #ffffff;
+  --bg-elevated: #f2f2f8;
+  --bg-card: #f5f5fa;
+  --bg-card-hover: #eeeef5;
+  --border: #d8d8e4;
+  --border-subtle: #e4e4ee;
+
+  --text-primary: #14162e;
+  --text-secondary: #52546e;
+  --text-muted: #8a8ca4;
+
+  --accent: #0070b8;
+  --accent-dim: rgba(0, 112, 184, 0.07);
+  --accent-glow: rgba(0, 112, 184, 0.14);
+  --accent-bright: #0088dd;
+  --accent-text: #0068aa;
+
+  --gold: #b88820;
+  --gold-dim: rgba(184, 136, 32, 0.07);
+  --gold-glow: rgba(184, 136, 32, 0.12);
+  --gold-text: #9a7018;
+
+  --tag-bg: rgba(0, 112, 184, 0.06);
+  --tag-text: #0068a0;
+  --tag-border: rgba(0, 112, 184, 0.15);
+
+  --theme: light;
+}
+
+/* --- Reset & Base --- */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+  scroll-padding-top: var(--nav-height);
+}
+
+body {
+  font-family: var(--font-body);
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--text-primary);
+  background: var(--bg-deep);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+}
+
+::selection {
+  background: var(--accent);
+  color: #fff;
+}
+
+a {
+  color: var(--accent-text);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+a:hover {
+  color: var(--accent-bright);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+/* --- Skip Link --- */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 16px;
+  padding: 8px 16px;
+  background: var(--accent);
+  color: #fff;
+  border-radius: var(--radius-sm);
+  font-size: 0.88rem;
+  font-weight: 500;
+  z-index: 10000;
+  transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+  top: 12px;
+  color: #fff;
+}
+
+/* --- Focus Styles --- */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+button:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+/* --- Typography --- */
+h1, h2, h3, h4 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+}
+
+h1 { font-size: clamp(2.8rem, 6vw, 4.5rem); }
+h2 { font-size: clamp(2rem, 4vw, 3rem); }
+h3 { font-size: clamp(1.3rem, 2.5vw, 1.8rem); }
+h4 { font-size: 1.15rem; font-family: var(--font-body); font-weight: 600; }
+
+p {
+  color: var(--text-secondary);
+  max-width: 68ch;
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+}
+
+/* --- Layout --- */
+.container {
+  max-width: var(--container-max);
+  margin: 0 auto;
+  padding: 0 var(--container-pad);
+}
+
+section {
+  padding: var(--section-pad) 0;
+  position: relative;
+}
+
+section:nth-child(even) {
+  background: var(--bg-primary);
+}
+
+section:nth-child(odd) {
+  background: var(--bg-deep);
+}
+
+/* --- Section Headers --- */
+.section-label {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-text);
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.section-label::before {
+  content: '';
+  width: 24px;
+  height: 1px;
+  background: var(--accent);
+  opacity: 0.5;
+}
+
+.section-title {
+  margin-bottom: 16px;
+}
+
+.section-desc {
+  font-size: 1.05rem;
+  margin-bottom: 48px;
+}
+
+/* --- Navigation --- */
+.nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--nav-height);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  transition: background 0.35s ease, border-color 0.35s ease, backdrop-filter 0.35s ease;
+  border-bottom: 1px solid transparent;
+}
+
+.nav.scrolled {
+  background: rgba(4, 5, 14, 0.85);
+  backdrop-filter: blur(20px) saturate(1.2);
+  -webkit-backdrop-filter: blur(20px) saturate(1.2);
+  border-bottom-color: var(--border-subtle);
+}
+
+[data-theme="light"] .nav.scrolled {
+  background: rgba(255, 255, 255, 0.88);
+}
+
+.nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  max-width: var(--container-max);
+  margin: 0 auto;
+  padding: 0 var(--container-pad);
+}
+
+.nav-brand {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: -0.01em;
+}
+
+.nav-brand:hover {
+  color: var(--accent-text);
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  list-style: none;
+}
+
+.nav-links a {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: color 0.2s ease;
+  letter-spacing: 0.01em;
+}
+
+.nav-links a:hover {
+  color: var(--text-primary);
+}
+
+.nav-links a.active {
+  color: var(--accent-text);
+}
+
+.theme-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: all 0.2s ease;
+  font-size: 1rem;
+}
+
+.theme-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent-text);
+}
+
+.nav-hamburger {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  color: var(--text-primary);
+}
+
+.nav-hamburger span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: currentColor;
+  margin: 5px 0;
+  transition: all 0.3s ease;
+  border-radius: 1px;
+}
+
+.nav-hamburger.open span:nth-child(1) {
+  transform: rotate(45deg) translate(5px, 5px);
+}
+.nav-hamburger.open span:nth-child(2) {
+  opacity: 0;
+}
+.nav-hamburger.open span:nth-child(3) {
+  transform: rotate(-45deg) translate(5px, -5px);
+}
+
+/* --- Hero --- */
+.hero {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+  background: var(--bg-deep);
+  padding-top: var(--nav-height);
+}
+
+.hero-canvas {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.hero-gradient {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background:
+    radial-gradient(ellipse 60% 50% at 70% 50%, rgba(0, 180, 236, 0.04) 0%, transparent 70%),
+    radial-gradient(ellipse 40% 60% at 20% 80%, rgba(212, 160, 48, 0.03) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+[data-theme="light"] .hero-gradient {
+  background:
+    radial-gradient(ellipse 60% 50% at 70% 50%, rgba(0, 112, 184, 0.05) 0%, transparent 70%),
+    radial-gradient(ellipse 40% 60% at 20% 80%, rgba(184, 136, 32, 0.04) 0%, transparent 60%);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 3;
+}
+
+.hero-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent-text);
+  margin-bottom: 20px;
+  opacity: 0;
+  animation: fadeUp 0.8s var(--ease-out) 0.2s forwards;
+}
+
+.hero h1 {
+  margin-bottom: 24px;
+  opacity: 0;
+  animation: fadeUp 0.8s var(--ease-out) 0.35s forwards;
+}
+
+.hero h1 em {
+  font-style: italic;
+  color: var(--accent-text);
+}
+
+.hero-tagline {
+  font-size: clamp(1.05rem, 2vw, 1.2rem);
+  line-height: 1.75;
+  max-width: 560px;
+  margin-bottom: 40px;
+  opacity: 0;
+  animation: fadeUp 0.8s var(--ease-out) 0.5s forwards;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  opacity: 0;
+  animation: fadeUp 0.8s var(--ease-out) 0.65s forwards;
+}
+
+/* --- Buttons --- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 28px;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.25s var(--ease-out);
+  border: none;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: var(--accent-bright);
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 8px 24px var(--accent-glow);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+}
+
+.btn-ghost:hover {
+  border-color: var(--accent);
+  color: var(--accent-text);
+  transform: translateY(-1px);
+}
+
+.btn-sm {
+  padding: 8px 18px;
+  font-size: 0.82rem;
+}
+
+/* --- About --- */
+.about-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 64px;
+  align-items: start;
+}
+
+.about-text p {
+  margin-bottom: 20px;
+}
+
+.about-text p:last-child {
+  margin-bottom: 0;
+}
+
+.about-sidebar h3 {
+  margin-bottom: 20px;
+}
+
+.education-item {
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.education-item:last-child {
+  border-bottom: none;
+}
+
+.education-degree {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.education-school {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+
+.education-year {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.skills-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 28px;
+}
+
+.skill-pill {
+  padding: 6px 14px;
+  border-radius: 100px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  background: var(--accent-dim);
+  color: var(--accent-text);
+  border: 1px solid var(--tag-border);
+  transition: all 0.2s ease;
+}
+
+.skill-pill:hover {
+  background: var(--accent-glow);
+  transform: translateY(-1px);
+}
+
+/* --- Portfolio Grid --- */
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+}
+
+.project-card {
+  position: relative;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 32px;
+  transition: all 0.35s var(--ease-out);
+  display: flex;
+  flex-direction: column;
+}
+
+.project-card:hover {
+  background: var(--bg-card-hover);
+  border-color: var(--accent);
+  transform: translateY(-3px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15), 0 0 0 1px var(--accent-dim);
+}
+
+.project-card.featured {
+  grid-column: span 2;
+  background: linear-gradient(135deg, var(--bg-card) 0%, rgba(0, 180, 236, 0.03) 100%);
+  border-color: rgba(0, 180, 236, 0.2);
+}
+
+.project-card.featured:hover {
+  border-color: var(--accent);
+}
+
+.card-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--gold-text);
+  background: var(--gold-dim);
+  padding: 4px 12px;
+  border-radius: 100px;
+  margin-bottom: 16px;
+  width: fit-content;
+}
+
+.card-badge::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--gold);
+}
+
+.project-card h3 {
+  margin-bottom: 10px;
+  color: var(--text-primary);
+}
+
+.project-card p {
+  font-size: 0.92rem;
+  margin-bottom: 20px;
+  flex-grow: 1;
+}
+
+.card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.tag {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  padding: 3px 10px;
+  border-radius: 4px;
+  background: var(--tag-bg);
+  color: var(--tag-text);
+  border: 1px solid var(--tag-border);
+}
+
+.card-links {
+  display: flex;
+  gap: 16px;
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.card-link {
+  font-size: 0.85rem;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  transition: color 0.2s ease;
+}
+
+.card-link:hover {
+  color: var(--accent-text);
+}
+
+.card-link svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* --- Research Preview --- */
+.research-preview {
+  background: var(--bg-deep);
+}
+
+.research-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  margin-bottom: 40px;
+}
+
+.research-card {
+  position: relative;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 32px 28px;
+  transition: all 0.35s var(--ease-out);
+  overflow: hidden;
+}
+
+.research-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--gold), transparent);
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.research-card:hover {
+  border-color: var(--gold);
+  transform: translateY(-3px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+}
+
+.research-card:hover::before {
+  opacity: 1;
+}
+
+.research-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-sm);
+  background: var(--gold-dim);
+  border: 1px solid rgba(212, 160, 48, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+  font-size: 1.25rem;
+}
+
+.research-card h3 {
+  font-size: 1.35rem;
+  margin-bottom: 8px;
+  color: var(--text-primary);
+}
+
+.research-card .research-field {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--gold-text);
+  letter-spacing: 0.04em;
+  margin-bottom: 14px;
+}
+
+.research-card p {
+  font-size: 0.9rem;
+  margin-bottom: 20px;
+}
+
+.research-status {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.research-status::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--gold);
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+
+/* --- Publications --- */
+.publications-list {
+  list-style: none;
+}
+
+.pub-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  transition: background 0.2s ease;
+}
+
+.pub-item:last-child {
+  border-bottom: none;
+}
+
+.pub-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+  line-height: 1.45;
+}
+
+.pub-title a {
+  color: var(--text-primary);
+}
+
+.pub-title a:hover {
+  color: var(--accent-text);
+}
+
+.pub-authors {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.pub-authors .self {
+  color: var(--accent-text);
+  font-weight: 600;
+}
+
+.pub-journal {
+  font-size: 0.85rem;
+  font-style: italic;
+  color: var(--text-secondary);
+}
+
+.pub-year {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.pub-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  margin-top: 24px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 0.88rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.pub-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent-text);
+}
+
+.pub-toggle svg {
+  transition: transform 0.3s ease;
+}
+
+.pub-toggle.expanded svg {
+  transform: rotate(180deg);
+}
+
+.pub-hidden {
+  display: none;
+}
+
+.pub-hidden.show {
+  display: block;
+}
+
+/* --- Contact --- */
+.contact-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 64px;
+  align-items: start;
+}
+
+.contact-info p {
+  margin-bottom: 24px;
+}
+
+.contact-links {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 32px;
+}
+
+.contact-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  transition: color 0.2s ease;
+}
+
+.contact-link:hover {
+  color: var(--accent-text);
+}
+
+.contact-link svg {
+  width: 20px;
+  height: 20px;
+  opacity: 0.7;
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-group label {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+}
+
+.form-group input,
+.form-group textarea {
+  padding: 12px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 0.92rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+
+.form-group textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+/* --- Footer --- */
+.footer {
+  padding: 40px 0;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-deep);
+}
+
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.footer-text {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.footer-links {
+  display: flex;
+  gap: 24px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  transition: color 0.2s ease;
+}
+
+.footer-links a:hover {
+  color: var(--text-primary);
+}
+
+/* --- Scroll Reveal --- */
+.reveal {
+  opacity: 0;
+  transform: translateY(28px);
+  transition: opacity 0.7s var(--ease-out), transform 0.7s var(--ease-out);
+}
+
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.reveal-delay-1 { transition-delay: 0.1s; }
+.reveal-delay-2 { transition-delay: 0.2s; }
+.reveal-delay-3 { transition-delay: 0.3s; }
+.reveal-delay-4 { transition-delay: 0.4s; }
+
+/* --- Animations --- */
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* --- Grain Overlay --- */
+.grain {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  opacity: 0.025;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 256px 256px;
+}
+
+[data-theme="light"] .grain {
+  opacity: 0.018;
+}
+
+/* --- Research Page Specific --- */
+.research-hero {
+  padding-top: calc(var(--nav-height) + 80px);
+  padding-bottom: 64px;
+  background: var(--bg-deep);
+}
+
+.research-detail {
+  padding: 64px 0;
+}
+
+.research-detail:nth-child(even) {
+  background: var(--bg-primary);
+}
+
+.research-detail:nth-child(odd) {
+  background: var(--bg-deep);
+}
+
+.research-detail-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+.research-detail-icon {
+  width: 56px;
+  height: 56px;
+  min-width: 56px;
+  border-radius: var(--radius-md);
+  background: var(--gold-dim);
+  border: 1px solid rgba(212, 160, 48, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+}
+
+.research-detail-meta .research-field {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--gold-text);
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+
+.research-highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  margin: 32px 0;
+}
+
+.highlight-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 20px 24px;
+}
+
+.highlight-item h4 {
+  font-size: 0.92rem;
+  margin-bottom: 6px;
+  color: var(--text-primary);
+}
+
+.highlight-item p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.research-cta {
+  margin-top: 40px;
+  padding: 32px;
+  background: var(--gold-dim);
+  border: 1px solid rgba(212, 160, 48, 0.15);
+  border-radius: var(--radius-md);
+  text-align: center;
+}
+
+.research-cta h4 {
+  color: var(--gold-text);
+  margin-bottom: 8px;
+}
+
+.research-cta p {
+  font-size: 0.9rem;
+  margin: 0 auto;
+}
+
+/* --- Responsive --- */
+@media (max-width: 900px) {
+  .about-grid,
+  .contact-grid {
+    grid-template-columns: 1fr;
+    gap: 48px;
+  }
+
+  .portfolio-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .project-card.featured {
+    grid-column: span 1;
+  }
+
+  .research-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  :root {
+    --nav-height: 56px;
+  }
+
+  .nav-links {
+    display: none;
+    position: fixed;
+    top: var(--nav-height);
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: var(--bg-deep);
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 32px;
+    z-index: 999;
+  }
+
+  [data-theme="light"] .nav-links {
+    background: var(--bg-primary);
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  .nav-links a {
+    font-size: 1.15rem;
+  }
+
+  .nav-hamburger {
+    display: block;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.2rem, 8vw, 3rem);
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .footer-inner {
+    flex-direction: column;
+    gap: 16px;
+    text-align: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .hero-actions .btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .project-card {
+    padding: 24px;
+  }
+
+  .research-card {
+    padding: 24px 20px;
+  }
+}
+
+/* Print */
+@media print {
+  .nav, .grain, .hero-canvas, .hero-gradient, .theme-toggle {
+    display: none !important;
+  }
+
+  body {
+    background: #fff;
+    color: #000;
+  }
+
+  section {
+    background: #fff !important;
+    padding: 24px 0;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,524 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blaine Heffron — Full-Stack Developer, Physics PhD, Independent Researcher</title>
+  <meta name="description" content="Blaine Heffron is a full-stack developer and physics PhD building smart contract tooling, educational platforms, and conducting independent research in mathematical physics, computational biology, and information-geometric economics.">
+  <meta name="author" content="Blaine Heffron">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://blaineheffron.com/">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Blaine Heffron — Developer & Researcher">
+  <meta property="og:description" content="Full-stack developer and physics PhD. Building smart contract tooling for Stellar, educational platforms, and independent research in mathematical physics and computational biology.">
+  <meta property="og:url" content="https://blaineheffron.com/">
+  <meta property="og:site_name" content="Blaine Heffron">
+  <meta property="og:image" content="https://blaineheffron.com/assets/media/sharing.png">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Blaine Heffron — Developer & Researcher">
+  <meta name="twitter:description" content="Full-stack developer and physics PhD. Smart contracts, educational platforms, and independent research.">
+  <meta name="twitter:image" content="https://blaineheffron.com/assets/media/sharing.png">
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Outfit:wght@300;400;500;600;700&family=Fira+Code:wght@400;500&display=swap">
+
+  <!-- Favicons -->
+  <link rel="icon" href="/static/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="/assets/media/apple-touch-icon.png">
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Blaine Heffron",
+    "url": "https://blaineheffron.com/",
+    "email": "mailto:blaine@blaineheffron.com",
+    "image": "https://blaineheffron.com/assets/media/sharing.png",
+    "description": "Full-stack developer and physics PhD building smart contract tooling for Stellar, educational platforms, and conducting independent research in mathematical physics, computational biology, and information-geometric economics.",
+    "jobTitle": "Full-Stack Developer & Independent Researcher",
+    "alumniOf": [
+      {
+        "@type": "CollegeOrUniversity",
+        "name": "University of Tennessee",
+        "department": "Physics"
+      },
+      {
+        "@type": "CollegeOrUniversity",
+        "name": "University of North Carolina"
+      }
+    ],
+    "hasCredential": [
+      {
+        "@type": "EducationalOccupationalCredential",
+        "credentialCategory": "degree",
+        "educationalLevel": "Doctoral",
+        "name": "PhD in Physics",
+        "recognizedBy": { "@type": "CollegeOrUniversity", "name": "University of Tennessee" },
+        "dateCreated": "2023"
+      },
+      {
+        "@type": "EducationalOccupationalCredential",
+        "credentialCategory": "degree",
+        "educationalLevel": "Master",
+        "name": "MS in Physics",
+        "recognizedBy": { "@type": "CollegeOrUniversity", "name": "University of Tennessee" },
+        "dateCreated": "2017"
+      },
+      {
+        "@type": "EducationalOccupationalCredential",
+        "credentialCategory": "degree",
+        "educationalLevel": "Bachelor",
+        "name": "BS in Physics",
+        "recognizedBy": { "@type": "CollegeOrUniversity", "name": "University of North Carolina" },
+        "dateCreated": "2012"
+      }
+    ],
+    "knowsAbout": ["Rust", "TypeScript", "Python", "Smart Contracts", "Stellar Blockchain", "Machine Learning", "Particle Physics", "Mathematical Physics", "Scientific Computing", "Signal Processing"],
+    "sameAs": [
+      "https://github.com/BlaineHeffron",
+      "https://www.linkedin.com/in/blaine-heffron",
+      "https://scholar.google.com/citations?user=8d-y4zoAAAAJ"
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Blaine Heffron",
+    "url": "https://blaineheffron.com/",
+    "author": { "@type": "Person", "name": "Blaine Heffron" }
+  }
+  </script>
+
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <a href="#hero" class="skip-link">Skip to content</a>
+  <div class="grain" aria-hidden="true"></div>
+
+  <!-- Navigation -->
+  <nav class="nav" role="navigation" aria-label="Main navigation">
+    <div class="nav-inner">
+      <a href="/" class="nav-brand">Blaine Heffron</a>
+      <ul class="nav-links" id="nav-links">
+        <li><a href="#about">About</a></li>
+        <li><a href="#work">Work</a></li>
+        <li><a href="#research">Research</a></li>
+        <li><a href="#publications">Publications</a></li>
+        <li><a href="#contact">Contact</a></li>
+        <li><a href="/static/uploads/resume.pdf" target="_blank" rel="noopener">CV</a></li>
+        <li>
+          <button class="theme-toggle" id="theme-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+            <span id="theme-icon">&#9789;</span>
+          </button>
+        </li>
+      </ul>
+      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <main>
+    <!-- Hero -->
+    <section class="hero" id="hero">
+      <canvas class="hero-canvas" id="hero-canvas" aria-hidden="true"></canvas>
+      <div class="hero-gradient" aria-hidden="true"></div>
+      <div class="container hero-content">
+        <p class="hero-eyebrow">Developer &middot; Physicist &middot; Researcher</p>
+        <h1>Building software<br>at the edge of <em>science</em></h1>
+        <p class="hero-tagline">I build smart contract tooling for Stellar, run an EdTech company, and do independent research in mathematical physics, computational biology, and information geometry. Physics PhD, 12+ years writing code.</p>
+        <div class="hero-actions">
+          <a href="#work" class="btn btn-primary">View Work</a>
+          <a href="/research.html" class="btn btn-ghost">Read Research</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- About -->
+    <section id="about">
+      <div class="container">
+        <div class="reveal">
+          <span class="section-label">About</span>
+          <h2 class="section-title">Background</h2>
+        </div>
+        <div class="about-grid">
+          <div class="about-text reveal reveal-delay-1">
+            <p>I got my physics PhD from the University of Tennessee in 2023, where I worked on the PROSPECT neutrino experiment at Oak Ridge. Most of that was signal processing, particle transport simulation, and machine learning to squeeze better measurements out of noisy detector data.</p>
+            <p>Right now I'm building <a href="https://github.com/BlaineHeffron/soroban-sdk-tools" target="_blank" rel="noopener">soroban-sdk-tools</a> on a <strong>Stellar Community Fund grant</strong> -- derive macros that make Soroban smart contract development less painful. I'm also lead developer for <a href="https://songcraftgame.com" target="_blank" rel="noopener">Songcraft</a>, a music reading game for kids.</p>
+            <p>On the research side, I'm working on three projects that share a common mathematical backbone: division algebras in particle physics, multi-scale biological simulation, and information-geometric economics. More on that <a href="/research.html">here</a>.</p>
+            <div class="skills-grid">
+              <span class="skill-pill">Rust</span>
+              <span class="skill-pill">TypeScript</span>
+              <span class="skill-pill">Python</span>
+              <span class="skill-pill">Soroban / Stellar</span>
+              <span class="skill-pill">Node.js</span>
+              <span class="skill-pill">React / Preact</span>
+              <span class="skill-pill">Machine Learning</span>
+              <span class="skill-pill">Scientific Computing</span>
+              <span class="skill-pill">Signal Processing</span>
+              <span class="skill-pill">Smart Contracts</span>
+            </div>
+          </div>
+          <div class="about-sidebar reveal reveal-delay-2">
+            <h3>Education</h3>
+            <div class="education-item">
+              <div class="education-degree">PhD in Physics</div>
+              <div class="education-school">University of Tennessee</div>
+              <div class="education-year">2023</div>
+            </div>
+            <div class="education-item">
+              <div class="education-degree">MS in Physics</div>
+              <div class="education-school">University of Tennessee</div>
+              <div class="education-year">2017</div>
+            </div>
+            <div class="education-item">
+              <div class="education-degree">BS in Physics</div>
+              <div class="education-school">University of North Carolina</div>
+              <div class="education-year">2012</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Work / Portfolio -->
+    <section id="work">
+      <div class="container">
+        <div class="reveal">
+          <span class="section-label">Portfolio</span>
+          <h2 class="section-title">Selected Work</h2>
+          <p class="section-desc">Open-source tools, production apps, and research code.</p>
+        </div>
+        <div class="portfolio-grid">
+
+          <!-- Featured: soroban-sdk-tools -->
+          <article class="project-card featured reveal reveal-delay-1">
+            <span class="card-badge">SCF Grant Recipient</span>
+            <h3>soroban-sdk-tools</h3>
+            <p>Derive macros for Soroban smart contracts that handle storage keys and error codes with compile-time uniqueness checks. Less boilerplate, fewer runtime surprises.</p>
+            <div class="card-tags">
+              <span class="tag">Rust</span>
+              <span class="tag">Stellar</span>
+              <span class="tag">Soroban</span>
+              <span class="tag">Smart Contracts</span>
+            </div>
+            <div class="card-links">
+              <a href="https://github.com/BlaineHeffron/soroban-sdk-tools" target="_blank" rel="noopener" class="card-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+                GitHub
+              </a>
+              <a href="https://github.com/BlaineHeffron/soroban-sdk-tools-demo" target="_blank" rel="noopener" class="card-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                Demo
+              </a>
+            </div>
+          </article>
+
+          <!-- Featured: Songcraft -->
+          <article class="project-card featured reveal reveal-delay-2">
+            <h3>Songcraft</h3>
+            <p>A music reading game where kids play along with sheet music in real time. Teachers can run classroom sessions, parents can track progress. Built on MusicXML with live note matching via WebSockets.</p>
+            <div class="card-tags">
+              <span class="tag">TypeScript</span>
+              <span class="tag">EdTech</span>
+              <span class="tag">WebSockets</span>
+              <span class="tag">Node.js</span>
+            </div>
+            <div class="card-links">
+              <a href="https://songcraftgame.com" target="_blank" rel="noopener" class="card-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                Live Site
+              </a>
+              <a href="https://github.com/BlaineHeffron/algorhythmiclabs" target="_blank" rel="noopener" class="card-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+                GitHub
+              </a>
+            </div>
+          </article>
+
+          <!-- paper-search-mcp -->
+          <article class="project-card reveal reveal-delay-1">
+            <h3>paper-search-mcp</h3>
+            <p>MCP server for searching and indexing scientific papers across arXiv, Semantic Scholar, OpenAlex, and 6 more sources. Local hybrid search with BM25 + SPECTER2 embeddings.</p>
+            <div class="card-tags">
+              <span class="tag">Rust</span>
+              <span class="tag">AI Tooling</span>
+              <span class="tag">MCP</span>
+            </div>
+            <div class="card-links">
+              <a href="https://github.com/BlaineHeffron/paper-search-mcp" target="_blank" rel="noopener" class="card-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+                GitHub
+              </a>
+            </div>
+          </article>
+
+          <!-- symbolic-math-mcp -->
+          <article class="project-card reveal reveal-delay-2">
+            <h3>symbolic-math-mcp</h3>
+            <p>MCP server for symbolic mathematics and tensor algebra. SymPy-powered CAS with Christoffel symbols, Riemann/Ricci/Einstein tensors, gamma algebra, and Fierz identities.</p>
+            <div class="card-tags">
+              <span class="tag">C++</span>
+              <span class="tag">SymPy</span>
+              <span class="tag">Physics</span>
+            </div>
+            <div class="card-links">
+              <a href="https://github.com/BlaineHeffron/symbolic-math-mcp" target="_blank" rel="noopener" class="card-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+                GitHub
+              </a>
+            </div>
+          </article>
+
+          <!-- ML for PROSPECT -->
+          <article class="project-card reveal reveal-delay-1">
+            <h3>ML for PROSPECT</h3>
+            <p>CNN/GCN-based event reconstruction for the PROSPECT neutrino detector. Achieved 3.3% improvement in signal statistics for the short-baseline oscillation search.</p>
+            <div class="card-tags">
+              <span class="tag">Python</span>
+              <span class="tag">Deep Learning</span>
+              <span class="tag">Physics</span>
+            </div>
+            <div class="card-links">
+              <a href="https://github.com/BlaineHeffron/WaveformML" target="_blank" rel="noopener" class="card-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+                GitHub
+              </a>
+              <a href="/static/uploads/PROSPECT_SE_ML_Summary.pdf" target="_blank" rel="noopener" class="card-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                Slides
+              </a>
+            </div>
+          </article>
+
+          <!-- dueno-monitor -->
+          <article class="project-card reveal reveal-delay-2">
+            <h3>dueno-monitor</h3>
+            <p>Remote server monitoring dashboard with real-time tmux and Claude Code session management. WebSocket-driven with live terminal output.</p>
+            <div class="card-tags">
+              <span class="tag">JavaScript</span>
+              <span class="tag">Fastify</span>
+              <span class="tag">WebSocket</span>
+            </div>
+            <div class="card-links">
+              <a href="https://github.com/BlaineHeffron/dueno-monitor" target="_blank" rel="noopener" class="card-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+                GitHub
+              </a>
+            </div>
+          </article>
+
+          <!-- Inventorium -->
+          <article class="project-card reveal reveal-delay-1">
+            <h3>Inventorium</h3>
+            <p>Inventory management app with an Astro marketing site. Tracks stock, generates reports, handles multi-location workflows.</p>
+            <div class="card-tags">
+              <span class="tag">TypeScript</span>
+              <span class="tag">Astro</span>
+            </div>
+            <div class="card-links">
+              <a href="https://github.com/BlaineHeffron/Inventorium" target="_blank" rel="noopener" class="card-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+                GitHub
+              </a>
+            </div>
+          </article>
+
+          <!-- EvoHabit -->
+          <article class="project-card reveal reveal-delay-2">
+            <h3>EvoHabit</h3>
+            <p>Habit tracker that adapts to how you actually behave, not how you wish you did. Streak logic, flexible scheduling, progress visualization.</p>
+            <div class="card-tags">
+              <span class="tag">TypeScript</span>
+            </div>
+            <div class="card-links">
+              <a href="https://github.com/BlaineHeffron/EvoHabit" target="_blank" rel="noopener" class="card-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+                GitHub
+              </a>
+            </div>
+          </article>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- Research Preview -->
+    <section id="research" class="research-preview">
+      <div class="container">
+        <div class="reveal">
+          <span class="section-label">Research</span>
+          <h2 class="section-title">Independent Research</h2>
+          <p class="section-desc">Three research programs that share a common mathematical backbone. Papers headed to arXiv.</p>
+        </div>
+        <div class="research-grid">
+          <article class="research-card reveal reveal-delay-1">
+            <div class="research-icon" aria-hidden="true">&#x2B21;</div>
+            <h3>Octophysics</h3>
+            <div class="research-field">Mathematical Physics</div>
+            <p>Division algebra foundations of the Standard Model. Computational verification of gauge group emergence from octonionic structure, Clifford algebra chains Cl(6)&rarr;Cl(10), and Spin(10) grand unification.</p>
+            <div class="card-tags">
+              <span class="tag">Rust</span>
+              <span class="tag">Gauge Theory</span>
+              <span class="tag">Octonions</span>
+            </div>
+            <div class="research-status">Papers in preparation</div>
+          </article>
+
+          <article class="research-card reveal reveal-delay-2">
+            <div class="research-icon" aria-hidden="true">&#x2699;</div>
+            <h3>EmbryoSim</h3>
+            <div class="research-field">Computational Biology</div>
+            <p>Hierarchical embryonic development simulation across 5 biological scales using gauge theory, RG coarse-graining, fiber bundles, and topological invariants. From quantum to organism.</p>
+            <div class="card-tags">
+              <span class="tag">Rust</span>
+              <span class="tag">Fiber Bundles</span>
+              <span class="tag">Active Inference</span>
+            </div>
+            <div class="research-status">Papers in preparation</div>
+          </article>
+
+          <article class="research-card reveal reveal-delay-3">
+            <div class="research-icon" aria-hidden="true">&#x2234;</div>
+            <h3>Entronomy</h3>
+            <div class="research-field">Information-Geometric Economics</div>
+            <p>Economics grounded in information theory. KL-divergence replaces subjective utility. Validated on macroeconomic data with sloppy spectrum analysis and 100% crisis detection precision after calibration.</p>
+            <div class="card-tags">
+              <span class="tag">Rust</span>
+              <span class="tag">Fisher Information</span>
+              <span class="tag">Gauge Theory</span>
+            </div>
+            <div class="research-status">Papers in preparation</div>
+          </article>
+        </div>
+        <div class="reveal reveal-delay-4" style="text-align: center;">
+          <a href="/research.html" class="btn btn-ghost">Explore Research &rarr;</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Publications -->
+    <section id="publications">
+      <div class="container">
+        <div class="reveal">
+          <span class="section-label">Publications</span>
+          <h2 class="section-title">Academic Publications</h2>
+          <p class="section-desc">Selected publications from the PROSPECT neutrino experiment, LEGEND dark matter search, and other collaborations.</p>
+        </div>
+        <ul class="publications-list reveal reveal-delay-1" id="pub-list">
+          <li class="pub-item">
+            <div class="pub-title"><a href="https://doi.org/10.1088/1748-0221/20/08/P08006" target="_blank" rel="noopener">Machine learning for single-ended event reconstruction in PROSPECT experiment</a></div>
+            <div class="pub-authors">M. Andriamirado et al. (PROSPECT Collaboration)</div>
+            <div class="pub-journal"><em>JINST</em> <strong>20</strong>, P08006 (2025)</div>
+          </li>
+          <li class="pub-item">
+            <div class="pub-title">Final Search for Short-Baseline Neutrino Oscillations with the PROSPECT-I Detector at HFIR</div>
+            <div class="pub-authors">H.P. Mumm, M. Andriamirado et al.</div>
+            <div class="pub-journal"><em>Preprint</em> (2024)</div>
+          </li>
+          <li class="pub-item">
+            <div class="pub-title">Reactor Antineutrino Directionality Measurement with the PROSPECT-I Detector</div>
+            <div class="pub-authors">H. Mumm, M. Andriamirado et al.</div>
+            <div class="pub-journal"><em>Preprint</em> (2024)</div>
+          </li>
+          <li class="pub-item">
+            <div class="pub-title"><a href="https://doi.org/10.1103/PhysRevLett.131.021802" target="_blank" rel="noopener">Final Measurement of the &sup2;&sup3;&sup5;U Antineutrino Energy Spectrum with the PROSPECT-I Detector at HFIR</a></div>
+            <div class="pub-authors">M. Andriamirado, A.B. Balantekin, ... <span class="self">B. Heffron</span>, ... et al. (PROSPECT Collaboration)</div>
+            <div class="pub-journal"><em>Phys. Rev. Lett.</em> <strong>131</strong>, 021802 (2023)</div>
+          </li>
+          <li class="pub-item">
+            <div class="pub-title">Joint Measurement of the &sup2;&sup3;&sup5;U Antineutrino Spectrum by PROSPECT and STEREO</div>
+            <div class="pub-authors">H. Almazan, M. Andriamirado et al.</div>
+            <div class="pub-journal"><em>Phys. Rev. Lett.</em> <strong>128</strong>, 081802 (2022)</div>
+          </li>
+          <li class="pub-item">
+            <div class="pub-title">Joint Determination of Reactor Antineutrino Spectra from &sup2;&sup3;&sup5;U and &sup2;&sup3;&sup9;Pu Fission by Daya Bay and PROSPECT</div>
+            <div class="pub-authors">F.P. An, M. Andriamirado et al.</div>
+            <div class="pub-journal"><em>Phys. Rev. Lett.</em> <strong>128</strong>, 081801 (2022)</div>
+          </li>
+          <!-- Additional publications loaded by JS -->
+        </ul>
+        <button class="pub-toggle reveal reveal-delay-2" id="pub-toggle" aria-expanded="false">
+          <span>Show all publications</span>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+      </div>
+    </section>
+
+    <!-- Contact -->
+    <section id="contact">
+      <div class="container">
+        <div class="reveal">
+          <span class="section-label">Contact</span>
+          <h2 class="section-title">Get in Touch</h2>
+        </div>
+        <div class="contact-grid">
+          <div class="contact-info reveal reveal-delay-1">
+            <p>Want to talk about a project, have questions about the research, or just want to say hi? Drop me a line.</p>
+            <div class="contact-links">
+              <a href="mailto:blaine@blaineheffron.com" class="contact-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+                blaine@blaineheffron.com
+              </a>
+              <a href="https://github.com/BlaineHeffron" target="_blank" rel="noopener" class="contact-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+                GitHub
+              </a>
+              <a href="https://www.linkedin.com/in/blaine-heffron" target="_blank" rel="noopener" class="contact-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>
+                LinkedIn
+              </a>
+              <a href="https://scholar.google.com/citations?user=8d-y4zoAAAAJ" target="_blank" rel="noopener" class="contact-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+                Google Scholar
+              </a>
+            </div>
+          </div>
+          <form class="contact-form reveal reveal-delay-2" action="https://formspree.io/f/xdoqagnv" method="POST">
+            <div class="form-row">
+              <div class="form-group">
+                <label for="name">Name</label>
+                <input type="text" id="name" name="name" required autocomplete="name">
+              </div>
+              <div class="form-group">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" required autocomplete="email">
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="message">Message</label>
+              <textarea id="message" name="message" required></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Send Message</button>
+          </form>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container footer-inner">
+      <span class="footer-text">&copy; 2026 Blaine Heffron</span>
+      <div class="footer-links">
+        <a href="https://github.com/BlaineHeffron" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://www.linkedin.com/in/blaine-heffron" target="_blank" rel="noopener">LinkedIn</a>
+        <a href="https://scholar.google.com/citations?user=8d-y4zoAAAAJ" target="_blank" rel="noopener">Scholar</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="/js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,464 @@
+/* ============================================
+   Blaine Heffron — Portfolio
+   Main JS: Canvas, Scroll, Theme, Publications
+   ============================================ */
+
+(function () {
+  'use strict';
+
+  // ---- Theme Toggle ----
+  const root = document.documentElement;
+  const themeToggle = document.getElementById('theme-toggle');
+  const themeIcon = document.getElementById('theme-icon');
+
+  function setTheme(theme) {
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+    themeIcon.textContent = theme === 'dark' ? '\u263D' : '\u2600';
+  }
+
+  const saved = localStorage.getItem('theme');
+  if (saved) {
+    setTheme(saved);
+  } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+    setTheme('light');
+  }
+
+  themeToggle.addEventListener('click', function () {
+    setTheme(root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+  });
+
+  // ---- Mobile Nav ----
+  const hamburger = document.getElementById('nav-hamburger');
+  const navLinks = document.getElementById('nav-links');
+
+  hamburger.addEventListener('click', function () {
+    const open = hamburger.classList.toggle('open');
+    navLinks.classList.toggle('open');
+    hamburger.setAttribute('aria-expanded', open);
+    document.body.style.overflow = open ? 'hidden' : '';
+  });
+
+  navLinks.addEventListener('click', function (e) {
+    if (e.target.tagName === 'A') {
+      hamburger.classList.remove('open');
+      navLinks.classList.remove('open');
+      hamburger.setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = '';
+    }
+  });
+
+  // ---- Sticky Nav Background ----
+  const nav = document.querySelector('.nav');
+  let lastScroll = 0;
+
+  function onScroll() {
+    const y = window.scrollY;
+    nav.classList.toggle('scrolled', y > 40);
+    lastScroll = y;
+  }
+
+  window.addEventListener('scroll', onScroll, { passive: true });
+  onScroll();
+
+  // ---- Scroll Reveal ----
+  const reveals = document.querySelectorAll('.reveal');
+  const observer = new IntersectionObserver(
+    function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.12, rootMargin: '0px 0px -40px 0px' }
+  );
+
+  reveals.forEach(function (el) {
+    observer.observe(el);
+  });
+
+  // ---- Hero Canvas: Heptagonal Lattice (G₂ Symmetry) ----
+  const canvas = document.getElementById('hero-canvas');
+  if (canvas) {
+    const ctx = canvas.getContext('2d');
+    let w, h, points, connections;
+    const isMobile = window.innerWidth < 768;
+    const RINGS = isMobile ? 3 : 5;
+    const BASE_RADIUS = isMobile ? 120 : 200;
+    const RING_GAP = isMobile ? 55 : 70;
+
+    function createLattice() {
+      points = [];
+      connections = [];
+
+      // Center point
+      points.push({ x: 0, y: 0, ring: 0, angle: 0, baseX: 0, baseY: 0 });
+
+      // Concentric rings of 7n points
+      for (let r = 1; r <= RINGS; r++) {
+        const count = 7 * r;
+        const radius = BASE_RADIUS + RING_GAP * (r - 1);
+        for (let i = 0; i < count; i++) {
+          const angle = (Math.PI * 2 * i) / count;
+          const x = Math.cos(angle) * radius;
+          const y = Math.sin(angle) * radius;
+          points.push({ x: x, y: y, ring: r, angle: angle, baseX: x, baseY: y });
+        }
+      }
+
+      // Connect adjacent points within rings and to nearest in adjacent rings
+      for (let i = 0; i < points.length; i++) {
+        for (let j = i + 1; j < points.length; j++) {
+          const dx = points[i].baseX - points[j].baseX;
+          const dy = points[i].baseY - points[j].baseY;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          const threshold = RING_GAP * 1.4;
+          if (dist < threshold) {
+            connections.push([i, j, dist]);
+          }
+        }
+      }
+    }
+
+    function resize() {
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      w = canvas.clientWidth;
+      h = canvas.clientHeight;
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      ctx.scale(dpr, dpr);
+      createLattice();
+    }
+
+    let time = 0;
+    let scrollFactor = 0;
+
+    function animate() {
+      time += 0.004;
+      scrollFactor = Math.min(window.scrollY / (h || 1), 1);
+
+      ctx.clearRect(0, 0, w, h);
+      ctx.save();
+      ctx.translate(w * 0.62, h * 0.48);
+
+      const globalAlpha = 0.15 * (1 - scrollFactor * 0.8);
+      const isDark = root.getAttribute('data-theme') !== 'light';
+      const lineColor = isDark ? '0, 180, 236' : '0, 100, 170';
+      const dotColor = isDark ? '0, 200, 255' : '0, 90, 160';
+
+      // Animate points
+      for (let i = 0; i < points.length; i++) {
+        const p = points[i];
+        if (p.ring === 0) continue;
+        const speed = 0.15 / p.ring;
+        const breath = Math.sin(time * 0.8 + p.ring * 0.7) * 6;
+        const rotOffset = time * speed;
+        const radius = Math.sqrt(p.baseX * p.baseX + p.baseY * p.baseY) + breath;
+        const angle = p.angle + rotOffset;
+        p.x = Math.cos(angle) * radius;
+        p.y = Math.sin(angle) * radius;
+      }
+
+      // Draw connections
+      const maxDist = RING_GAP * 1.4;
+      for (let c = 0; c < connections.length; c++) {
+        const a = points[connections[c][0]];
+        const b = points[connections[c][1]];
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        const alpha = globalAlpha * Math.max(0, 1 - dist / maxDist) * 0.6;
+        if (alpha < 0.005) continue;
+        ctx.beginPath();
+        ctx.moveTo(a.x, a.y);
+        ctx.lineTo(b.x, b.y);
+        ctx.strokeStyle = 'rgba(' + lineColor + ',' + alpha + ')';
+        ctx.lineWidth = 0.8;
+        ctx.stroke();
+      }
+
+      // Draw points
+      for (let i = 0; i < points.length; i++) {
+        const p = points[i];
+        const size = p.ring === 0 ? 2.5 : 1.5;
+        const alpha = globalAlpha * (p.ring === 0 ? 1.2 : 0.8);
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, size, 0, Math.PI * 2);
+        ctx.fillStyle = 'rgba(' + dotColor + ',' + alpha + ')';
+        ctx.fill();
+      }
+
+      ctx.restore();
+      requestAnimationFrame(animate);
+    }
+
+    window.addEventListener('resize', resize);
+    resize();
+    animate();
+  }
+
+  // ---- Publications ----
+  var publications = [
+    {
+      title: 'Machine learning for single-ended event reconstruction in PROSPECT experiment',
+      authors: 'M. Andriamirado et al. (PROSPECT Collaboration)',
+      journal: 'JINST',
+      volume: '20',
+      pages: 'P08006',
+      year: 2025,
+      doi: '10.1088/1748-0221/20/08/P08006',
+      featured: true
+    },
+    {
+      title: 'Final Search for Short-Baseline Neutrino Oscillations with the PROSPECT-I Detector at HFIR',
+      authors: 'H.P. Mumm, M. Andriamirado et al.',
+      journal: 'Preprint',
+      year: 2024,
+      featured: true
+    },
+    {
+      title: 'Reactor Antineutrino Directionality Measurement with the PROSPECT-I Detector',
+      authors: 'H. Mumm, M. Andriamirado et al.',
+      journal: 'Preprint',
+      year: 2024,
+      featured: true
+    },
+    {
+      title: 'Final Measurement of the \u00B2\u00B3\u2075U Antineutrino Energy Spectrum with the PROSPECT-I Detector at HFIR',
+      authors: 'M. Andriamirado, A.B. Balantekin, ... B. Heffron, ... et al. (PROSPECT Collaboration)',
+      journal: 'Phys. Rev. Lett.',
+      volume: '131',
+      pages: '021802',
+      year: 2023,
+      doi: '10.1103/PhysRevLett.131.021802',
+      featured: true
+    },
+    {
+      title: 'Joint Measurement of the \u00B2\u00B3\u2075U Antineutrino Spectrum by PROSPECT and STEREO',
+      authors: 'H. Almazan, M. Andriamirado et al.',
+      journal: 'Phys. Rev. Lett.',
+      volume: '128',
+      pages: '081802',
+      year: 2022,
+      doi: null
+    },
+    {
+      title: 'Joint Determination of Reactor Antineutrino Spectra from \u00B2\u00B3\u2075U and \u00B2\u00B3\u2079Pu Fission by Daya Bay and PROSPECT',
+      authors: 'F.P. An, M. Andriamirado et al.',
+      journal: 'Phys. Rev. Lett.',
+      volume: '128',
+      pages: '081801',
+      year: 2022,
+      doi: null
+    },
+    {
+      title: 'PROSPECT-II Physics Opportunities',
+      authors: 'M. Andriamirado et al.',
+      journal: 'J. Phys. G',
+      volume: '49',
+      pages: '070501',
+      year: 2022,
+      doi: null
+    },
+    {
+      title: 'Calibration Strategy of the PROSPECT-II Detector with External and Intrinsic Sources',
+      authors: 'M. Andriamirado et al.',
+      journal: 'arXiv:2211.09582',
+      year: 2022,
+      doi: null
+    },
+    {
+      title: 'Limits on Sub-GeV Dark Matter from the PROSPECT Reactor Antineutrino Experiment',
+      authors: 'M. Andriamirado et al.',
+      journal: 'Phys. Rev. D',
+      volume: '104',
+      pages: '012009',
+      year: 2021,
+      doi: null
+    },
+    {
+      title: 'LEGEND-1000 Preconceptual Design Report',
+      authors: 'N. Abgrall et al.',
+      journal: 'arXiv:2107.11462',
+      year: 2021,
+      doi: null
+    },
+    {
+      title: 'Nonfuel Antineutrino Contributions in the ORNL High Flux Isotope Reactor (HFIR)',
+      authors: 'A.B. Balantekin et al.',
+      journal: 'Phys. Rev. C',
+      volume: '101',
+      pages: '054605',
+      year: 2020,
+      doi: null
+    },
+    {
+      title: 'The PROSPECT Reactor Antineutrino Experiment',
+      authors: 'J. Ashenfelter et al.',
+      journal: 'Nucl. Instrum. Methods A',
+      volume: '922',
+      pages: '287\u2013309',
+      year: 2019,
+      doi: null
+    },
+    {
+      title: 'First Search for Short-Baseline Neutrino Oscillations at HFIR with PROSPECT',
+      authors: 'PROSPECT Collaboration, J. Ashenfelter et al.',
+      journal: 'Phys. Rev. Lett.',
+      volume: '121',
+      pages: '251802',
+      year: 2018,
+      doi: null
+    },
+    {
+      title: 'Performance of a Segmented \u2076Li-Loaded Liquid Scintillator Detector for the PROSPECT Experiment',
+      authors: 'J. Ashenfelter et al.',
+      journal: 'JINST',
+      volume: '13',
+      pages: 'P06023',
+      year: 2018,
+      doi: null
+    },
+    {
+      title: 'Proton Elastic Scattering at 200A MeV and High Momentum Transfers as a Probe of the Nuclear Matter Density of \u2076He',
+      authors: 'S. Chebotaryov, S. Sakaguchi et al.',
+      journal: 'Prog. Theor. Exp. Phys.',
+      volume: '2018',
+      pages: '053D01',
+      year: 2018,
+      doi: null
+    },
+    {
+      title: 'Characterization of Reactor Background Radiation at HFIR for the PROSPECT Experiment',
+      authors: 'B.A. Heffron',
+      journal: "Master's Thesis, University of Tennessee",
+      year: 2017,
+      doi: null,
+      featured: true
+    },
+    {
+      title: 'The PROSPECT Physics Program',
+      authors: 'J. Ashenfelter et al.',
+      journal: 'J. Phys. G',
+      volume: '43',
+      pages: '113001',
+      year: 2016,
+      doi: null
+    },
+    {
+      title: 'Background Radiation Measurements at High Power Research Reactors',
+      authors: 'J. Ashenfelter et al.',
+      journal: 'Nucl. Instrum. Methods A',
+      volume: '806',
+      pages: '401\u2013419',
+      year: 2016,
+      doi: null
+    },
+    {
+      title: 'Decays of the Three Top Contributors to the Reactor Antineutrino High-Energy Spectrum Studied with Total Absorption Spectroscopy',
+      authors: 'B.C. Rasco et al.',
+      journal: 'Phys. Rev. Lett.',
+      volume: '117',
+      pages: '092501',
+      year: 2016,
+      doi: null
+    },
+    {
+      title: 'Light Collection and Pulse-Shape Discrimination in Elongated Scintillator Cells for PROSPECT',
+      authors: 'J. Ashenfelter et al.',
+      journal: 'JINST',
+      volume: '10',
+      pages: 'P11004',
+      year: 2015,
+      doi: null
+    },
+    {
+      title: 'Relationship Between Boundary Layer Heights and Growth Rates with Ground-Level Ozone in Houston, Texas',
+      authors: 'C.L. Haman, E. Couzo, J.H. Flynn, W. Vizuete, B. Heffron, B.L. Lefer',
+      journal: 'J. Geophys. Res. Atmos.',
+      volume: '119',
+      pages: '6230\u20136245',
+      year: 2014,
+      doi: null
+    },
+    {
+      title: 'PROSPECT \u2014 A Precision Reactor Oscillation and Spectrum Experiment at Short Baselines',
+      authors: 'J. Ashenfelter et al.',
+      journal: 'arXiv:1309.7647',
+      year: 2013,
+      doi: null
+    }
+  ];
+
+  // First 6 publications are pre-rendered in HTML for SEO.
+  // JS appends the remaining ones as hidden (expandable).
+  var HTML_PRERENDERED = 6;
+  var pubList = document.getElementById('pub-list');
+  var pubToggle = document.getElementById('pub-toggle');
+
+  if (pubList) {
+    publications.forEach(function (pub, i) {
+      if (i < HTML_PRERENDERED) return; // already in HTML
+
+      var li = document.createElement('li');
+      li.className = 'pub-item pub-hidden';
+
+      var titleHtml = pub.title;
+      if (pub.doi) {
+        titleHtml = '<a href="https://doi.org/' + pub.doi + '" target="_blank" rel="noopener">' + pub.title + '</a>';
+      }
+
+      var journalLine = '<em>' + pub.journal + '</em>';
+      if (pub.volume) journalLine += ' <strong>' + pub.volume + '</strong>';
+      if (pub.pages) journalLine += ', ' + pub.pages;
+
+      var authorsHtml = pub.authors.replace(/(Heffron|B\.\s*Heffron|B\.A\.\s*Heffron)/gi, '<span class="self">$1</span>');
+
+      li.innerHTML =
+        '<div class="pub-title">' + titleHtml + '</div>' +
+        '<div class="pub-authors">' + authorsHtml + '</div>' +
+        '<div class="pub-journal">' + journalLine + ' (' + pub.year + ')</div>';
+
+      pubList.appendChild(li);
+    });
+  }
+
+  if (pubToggle) {
+    pubToggle.addEventListener('click', function () {
+      var hidden = pubList.querySelectorAll('.pub-hidden');
+      var expanded = pubToggle.classList.toggle('expanded');
+      pubToggle.setAttribute('aria-expanded', expanded);
+      hidden.forEach(function (el) {
+        el.classList.toggle('show');
+      });
+      pubToggle.querySelector('span').textContent = expanded
+        ? 'Show fewer'
+        : 'Show all publications';
+    });
+  }
+
+  // ---- Active Nav Link ----
+  var sections = document.querySelectorAll('section[id]');
+  var navAnchors = document.querySelectorAll('.nav-links a[href^="#"]');
+
+  var sectionObserver = new IntersectionObserver(
+    function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          var id = entry.target.getAttribute('id');
+          navAnchors.forEach(function (a) {
+            a.classList.toggle('active', a.getAttribute('href') === '#' + id);
+          });
+        }
+      });
+    },
+    { threshold: 0.3 }
+  );
+
+  sections.forEach(function (s) {
+    sectionObserver.observe(s);
+  });
+
+})();

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,21 +1,34 @@
 [build]
-  command = "hugo --gc --minify -b $URL"
-  publish = "public"
+  command = "echo 'Static site - no build needed'"
+  publish = "."
 
-[build.environment]
-  HUGO_VERSION = "0.119.0"
-  HUGO_ENABLEGITINFO = "true"
+[[headers]]
+  for = "/css/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
 
-[context.production.environment]
-  HUGO_ENV = "production"
+[[headers]]
+  for = "/js/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
 
-[context.deploy-preview]
-  command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+[[headers]]
+  for = "/static/fonts/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
 
-[context.branch-deploy]
-  command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; script-src 'self'; connect-src 'self' https://formspree.io; frame-ancestors 'self'"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
 
-[[plugins]]
-  package = "netlify-plugin-hugo-cache-resources"
-  [plugins.inputs]
-    debug = true
+# Clean URLs for research page
+[[redirects]]
+  from = "/research"
+  to = "/research.html"
+  status = 200

--- a/research.html
+++ b/research.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Research — Blaine Heffron</title>
+  <meta name="description" content="Independent research in mathematical physics (Octophysics), computational biology (EmbryoSim), and information-geometric economics (Entronomy) by Blaine Heffron.">
+  <meta name="author" content="Blaine Heffron">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://blaineheffron.com/research.html">
+
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Research — Blaine Heffron">
+  <meta property="og:description" content="Independent research in mathematical physics, computational biology, and information-geometric economics.">
+  <meta property="og:url" content="https://blaineheffron.com/research.html">
+  <meta property="og:site_name" content="Blaine Heffron">
+  <meta property="og:image" content="https://blaineheffron.com/assets/media/sharing.png">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Research — Blaine Heffron">
+  <meta name="twitter:description" content="Independent research in mathematical physics, computational biology, and information-geometric economics.">
+  <meta name="twitter:image" content="https://blaineheffron.com/assets/media/sharing.png">
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Research — Blaine Heffron",
+    "url": "https://blaineheffron.com/research.html",
+    "description": "Independent research in mathematical physics (Octophysics), computational biology (EmbryoSim), and information-geometric economics (Entronomy).",
+    "author": { "@type": "Person", "name": "Blaine Heffron", "url": "https://blaineheffron.com/" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://blaineheffron.com/" },
+      { "@type": "ListItem", "position": 2, "name": "Research", "item": "https://blaineheffron.com/research.html" }
+    ]
+  }
+  </script>
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Outfit:wght@300;400;500;600;700&family=Fira+Code:wght@400;500&display=swap">
+
+  <link rel="icon" href="/static/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="/assets/media/apple-touch-icon.png">
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <a href="#octophysics" class="skip-link">Skip to content</a>
+  <div class="grain" aria-hidden="true"></div>
+
+  <!-- Navigation -->
+  <nav class="nav" role="navigation" aria-label="Main navigation">
+    <div class="nav-inner">
+      <a href="/" class="nav-brand">Blaine Heffron</a>
+      <ul class="nav-links" id="nav-links">
+        <li><a href="/#about">About</a></li>
+        <li><a href="/#work">Work</a></li>
+        <li><a href="/research.html" class="active">Research</a></li>
+        <li><a href="/#publications">Publications</a></li>
+        <li><a href="/#contact">Contact</a></li>
+        <li><a href="/static/uploads/resume.pdf" target="_blank" rel="noopener">CV</a></li>
+        <li>
+          <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+            <span id="theme-icon">&#9789;</span>
+          </button>
+        </li>
+      </ul>
+      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <main>
+    <!-- Research Hero -->
+    <section class="research-hero">
+      <div class="container">
+        <span class="section-label reveal">Independent Research</span>
+        <h1 class="reveal reveal-delay-1" style="margin-bottom: 20px;">Research Programs</h1>
+        <p class="section-desc reveal reveal-delay-2" style="max-width: 640px;">I work on three problems that look different on the surface but use the same math underneath: gauge fields, renormalization, and topology. Here's what each one is about.</p>
+      </div>
+    </section>
+
+    <!-- Octophysics -->
+    <section class="research-detail" id="octophysics">
+      <div class="container">
+        <div class="research-detail-header reveal">
+          <div class="research-detail-icon" aria-hidden="true">&#x2B21;</div>
+          <div class="research-detail-meta">
+            <div class="research-field">Mathematical Physics</div>
+            <h2>Octophysics</h2>
+          </div>
+        </div>
+        <p class="reveal reveal-delay-1" style="margin-bottom: 24px;">Octophysics is a Rust library for division algebra approaches to particle physics. The central idea: the Standard Model gauge group SU(3)&times;SU(2)&times;U(1) isn't arbitrary. It falls out of octonionic structure when you build up through Clifford algebra chains.</p>
+        <p class="reveal reveal-delay-1" style="margin-bottom: 32px;">Everything is verified computationally to machine precision (&lt;10<sup>&minus;10</sup>). The Weinberg angle comes out to sin&sup2;(&theta;<sub>W</sub>) = 3/8 at the GUT scale, three fermion generations emerge from S&#8323; family symmetry, and Spin(10) grand unification drops out of the sterile neutrino stabilizer. 494 tests pass.</p>
+
+        <div class="research-highlights reveal reveal-delay-2">
+          <div class="highlight-item">
+            <h4>Clifford Algebra Chain</h4>
+            <p>Cl(6) &rarr; Cl(8) &rarr; Cl(10) construction with exact algebraic verification of SM representations.</p>
+          </div>
+          <div class="highlight-item">
+            <h4>G&#8322; Lattice Gauge Theory</h4>
+            <p>Quantum simulation infrastructure with glueball spectrum extraction and topological charge measurement.</p>
+          </div>
+          <div class="highlight-item">
+            <h4>494 Validated Tests</h4>
+            <p>Tests cover octonion algebra, Jordan algebras, Peirce decomposition, and lattice observables.</p>
+          </div>
+          <div class="highlight-item">
+            <h4>Exceptional Lie Algebras</h4>
+            <p>G&#8322;, F&#8324;, E&#8326; trajectory following Dray-Manogue-Wilson exceptional algebra tower construction.</p>
+          </div>
+        </div>
+
+        <div class="card-tags reveal reveal-delay-3" style="margin-top: 24px;">
+          <span class="tag">Rust</span>
+          <span class="tag">Octonions</span>
+          <span class="tag">Clifford Algebras</span>
+          <span class="tag">Gauge Theory</span>
+          <span class="tag">Spin(10)</span>
+          <span class="tag">Lattice QCD</span>
+        </div>
+
+        <div class="research-cta reveal reveal-delay-3">
+          <h4>Papers in Preparation</h4>
+          <p>Writing up the review paper now. Targets: arXiv and a journal submission covering the Cl(6) through Cl(10) construction.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- EmbryoSim -->
+    <section class="research-detail" id="embryosim">
+      <div class="container">
+        <div class="research-detail-header reveal">
+          <div class="research-detail-icon" aria-hidden="true">&#x2699;</div>
+          <div class="research-detail-meta">
+            <div class="research-field">Computational Biology</div>
+            <h2>EmbryoSim</h2>
+          </div>
+        </div>
+        <p class="reveal reveal-delay-1" style="margin-bottom: 24px;">EmbryoSim models embryonic development across five biological scales, using the same gauge theory and fiber bundle math from Octophysics but applied to cells and tissues instead of quarks.</p>
+        <p class="reveal reveal-delay-1" style="margin-bottom: 32px;">It starts at the quantum level (Layer 0) and coarse-grains upward through molecular, cellular, tissue, and organism scales. Each layer connects to the next via renormalization group transforms, so you don't lose the physics that matters at each scale. 46 integration tests cover everything from Turing pattern formation to full gastrulation simulations.</p>
+
+        <div class="research-highlights reveal reveal-delay-2">
+          <div class="highlight-item">
+            <h4>5-Layer Architecture</h4>
+            <p>Quantum (1&ndash;10&Aring;) &rarr; Molecular (1&ndash;100nm) &rarr; Cellular (1&ndash;100&mu;m) &rarr; Tissue (0.1&ndash;10mm) &rarr; Organism (1&ndash;100mm).</p>
+          </div>
+          <div class="highlight-item">
+            <h4>Active Nematic Dynamics</h4>
+            <p>2D/3D topological defect detection, tracking, and annihilation with Q-tensor field evolution.</p>
+          </div>
+          <div class="highlight-item">
+            <h4>Bioelectric Networks</h4>
+            <p>Gap junction gating with Vmem-morphogen coupling, Nernst/GHK equations, and prepatterning.</p>
+          </div>
+          <div class="highlight-item">
+            <h4>Active Inference</h4>
+            <p>Free energy principle drives tissue growth and morphogenetic decision-making at the tissue scale.</p>
+          </div>
+          <div class="highlight-item">
+            <h4>Persistent Homology</h4>
+            <p>Topological invariants track pattern evolution through sublevel and Vietoris-Rips filtrations.</p>
+          </div>
+          <div class="highlight-item">
+            <h4>46 Integration Tests</h4>
+            <p>Turing patterns, nematic defect annihilation, gastrulation, adaptive timestep, and checkpoint resume.</p>
+          </div>
+        </div>
+
+        <div class="card-tags reveal reveal-delay-3" style="margin-top: 24px;">
+          <span class="tag">Rust</span>
+          <span class="tag">Fiber Bundles</span>
+          <span class="tag">Active Inference</span>
+          <span class="tag">Morphogenesis</span>
+          <span class="tag">RG Coarse-Graining</span>
+          <span class="tag">Persistent Homology</span>
+        </div>
+
+        <div class="research-cta reveal reveal-delay-3">
+          <h4>Papers in Preparation</h4>
+          <p>The framework paper is in progress. Will cover the 5-layer architecture and the RG bridging between scales.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Entronomy -->
+    <section class="research-detail" id="entronomy">
+      <div class="container">
+        <div class="research-detail-header reveal">
+          <div class="research-detail-icon" aria-hidden="true">&#x2234;</div>
+          <div class="research-detail-meta">
+            <div class="research-field">Information-Geometric Economics</div>
+            <h2>Entronomy</h2>
+          </div>
+        </div>
+        <p class="reveal reveal-delay-1" style="margin-bottom: 24px;">Entronomy throws out subjective utility and replaces it with information geometry. Economic value becomes a KL-divergence: V(&theta;) = &minus;D<sub>KL</sub>(p(O|&theta;) || p(O|&theta;<sub>eq</sub>)). Same gauge theory and Fisher information math as the other two projects, different domain.</p>
+        <p class="reveal reveal-delay-1" style="margin-bottom: 32px;">I've tested this on FRED macroeconomic data, FX markets, and equity panels. The sloppy spectrum structure is there in all five countries I checked (R&sup2; &gt; 0.94). Crisis detection hits 100% precision after calibration, with the 2008 GFC showing up in the eigenvalue spectrum 17 months early.</p>
+
+        <div class="research-highlights reveal reveal-delay-2">
+          <div class="highlight-item">
+            <h4>Sloppy Spectrum Confirmed</h4>
+            <p>7-variable US panel: R&sup2; = 0.97 with 2.8 decades eigenvalue spread. Universal across 5 countries (all R&sup2; &gt; 0.94).</p>
+          </div>
+          <div class="highlight-item">
+            <h4>Crisis Detection</h4>
+            <p>100% recall, 100% precision (F1 = 1.0) after calibration. Pre-crisis dimension drop detected 17 months before GFC.</p>
+          </div>
+          <div class="highlight-item">
+            <h4>Gauge Structure Validated</h4>
+            <p>7-currency FX Wilson loops confirm flat connections. Independent validation across FRED and ECB cross-rates.</p>
+          </div>
+          <div class="highlight-item">
+            <h4>Fisher-Optimal Portfolios</h4>
+            <p>Outperforms Markowitz at short estimation windows. Information-geometric Kelly criterion for optimal bet sizing.</p>
+          </div>
+          <div class="highlight-item">
+            <h4>260 Passing Tests</h4>
+            <p>8 crates covering Fisher-Rao manifolds, homeostasis inference, gauge connections, critical phenomena, and empirical pipelines.</p>
+          </div>
+          <div class="highlight-item">
+            <h4>3 Research Papers</h4>
+            <p>Sloppy spectra in macro data, Fisher-optimal portfolios, and empirical gauge structure in currency markets.</p>
+          </div>
+        </div>
+
+        <div class="card-tags reveal reveal-delay-3" style="margin-top: 24px;">
+          <span class="tag">Rust</span>
+          <span class="tag">Fisher Information</span>
+          <span class="tag">KL-Divergence</span>
+          <span class="tag">Gauge Theory</span>
+          <span class="tag">Crisis Detection</span>
+          <span class="tag">Portfolio Theory</span>
+        </div>
+
+        <div class="research-cta reveal reveal-delay-3">
+          <h4>Papers in Preparation</h4>
+          <p>Three papers in draft: sloppy spectra in macro data, Fisher-optimal portfolios, and gauge structure in FX markets.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Unifying Thread -->
+    <section style="background: var(--bg-primary);">
+      <div class="container" style="text-align: center; max-width: 720px;">
+        <div class="reveal">
+          <span class="section-label" style="justify-content: center;">The Unifying Thread</span>
+          <h2 class="section-title" style="margin-bottom: 24px;">One Mathematical Framework, Three Domains</h2>
+        </div>
+        <p class="reveal reveal-delay-1" style="margin: 0 auto 24px; text-align: center;">The same math keeps showing up. Gauge connections describe how things relate across positions. RG tells you what survives when you zoom out. Topology tells you what can't be smoothly deformed away. These aren't metaphors -- they're the actual computational tools in all three codebases.</p>
+        <p class="reveal reveal-delay-2" style="margin: 0 auto 40px; text-align: center;">I think that's because the underlying problem is the same: how does structure at one scale produce structure at another? Whether you're asking that about quarks, embryos, or currency markets, the math doesn't care.</p>
+        <div class="reveal reveal-delay-3">
+          <a href="/#contact" class="btn btn-primary">Discuss This Research</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container footer-inner">
+      <span class="footer-text">&copy; 2026 Blaine Heffron</span>
+      <div class="footer-links">
+        <a href="https://github.com/BlaineHeffron" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://www.linkedin.com/in/blaine-heffron" target="_blank" rel="noopener">LinkedIn</a>
+        <a href="https://scholar.google.com/citations?user=8d-y4zoAAAAJ" target="_blank" rel="noopener">Scholar</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="/js/main.js"></script>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://blaineheffron.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://blaineheffron.com/</loc>
+    <lastmod>2026-03-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://blaineheffron.com/research.html</loc>
+    <lastmod>2026-03-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- Replace Hugo Academic theme with hand-built static HTML/CSS/JS (no build step, no npm)
- Single-page index with hero, about, 9 portfolio projects (soroban-sdk-tools SCF grant featured), research preview, 22 publications, contact form
- Dedicated research page for Octophysics, EmbryoSim, and Entronomy programs
- Dark/light theme with Instrument Serif + Outfit typography, animated G₂-symmetry lattice hero

## SEO
- JSON-LD: Person (with hasCredential for all 3 degrees), WebSite, WebPage, BreadcrumbList schemas
- Open Graph + Twitter cards on both pages with proper sharing image
- Google Fonts via `<link>` with preconnect (not CSS @import) for faster LCP
- robots.txt + sitemap.xml
- First 6 publications pre-rendered in HTML for non-JS crawlers
- CSP, HSTS, Permissions-Policy security headers in netlify.toml

## Content
- All copy humanized (first-person voice, no AI patterns)
- Skip-to-content links + custom focus-visible styles for accessibility

## Test plan
- [ ] Verify Netlify deploy preview renders correctly
- [ ] Check dark/light theme toggle
- [ ] Test mobile hamburger nav
- [ ] Confirm publications expand/collapse works
- [ ] Validate structured data with Google Rich Results Test
- [ ] Test social sharing previews (OG image)
- [ ] Verify contact form submits via Formspree
- [ ] Check sharing.png dimensions (should be 1200x630 for OG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)